### PR TITLE
Correcting typo in instructions for making tree-sitter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cp ./queries/* /path/to/tree-sitter-langs/queries/r
 ``` bash
 git clone https://github.com/r-lib/tree-sitter-r.git
 gcc ./src/parser.c ./src/scanner.c -lstdc++ -fPIC -I./ -I./src/ -I./src/tree_sitter --shared -o r.dll
-cp ./r.dll /path/to/tree-sitter-langs/langs/bin (/path/to/tree-sitter-langs/ is path of your tree-sitter-langs package)
+cp ./r.dll /path/to/tree-sitter-langs/langs/bin
 mkdir /path/to/tree-sitter-langs/queries/r
 cp ./queries/* /path/to/tree-sitter-langs/queries/r
 ```

--- a/README.md
+++ b/README.md
@@ -5,34 +5,49 @@
 
 # tree-sitter-ess-r
 
-R with tree-sitter support.
+[R](https://r-project.org) with [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) support.
 
 ## Installation
 
-Clone this repository, or install from MELPA. Add the following to your `.emacs`:
+Clone this repository, or install from MELPA. Add the following to your `init.el`:
 
 ``` elisp
 (require 'tree-sitter-ess-r)
 (add-hook 'ess-r-mode-hook 'tree-sitter-ess-r-mode-activate)
 ```
 
+If you use `use-package` you can install and configure with :
+
+``` elisp
+(use-package tree-sitter-ess-r
+  :ensure t
+  :after (ess)
+  :hook (ess-r-mode . tree-sitter-ess-r-mode-activate))
+```
+
 or call interactively `M-x tree-sitter-ess-r-using-r-faces`
 
-## Make tree-sitter to support r
+## Make tree-sitter to support R
 
-Linux
+`/path/to/tree-sitter-langs/` is the path of your
+[tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs) package.
 
-1. git clone https://github.com/r-lib/tree-sitter-r.git
-2. gcc ./src/parser.c ./src/scanner.cc -lstdc++ -fPIC -I./ -I./src/ -I./src/tree_sitter --shared -o r.so
-3. cp ./r.so /path/to/tree-sitter-langs/langs/bin (/path/to/tree-sitter-langs/ is path of your tree-sitter-langs package)
-4. mkdir /path/to/tree-sitter-langs/queries/r
-5. cp ./queries/* /path/to/tree-sitter-langs/queries/r
+### Linux
 
+``` bash
+git clone https://github.com/r-lib/tree-sitter-r.git && cd tree-sitter-r
+gcc ./src/parser.c ./src/scanner.c -lstdc++ -fPIC -I./ -I./src/ -I./src/tree_sitter --shared -o r.so
+cp ./r.so /path/to/tree-sitter-langs/langs/bin
+mkdir /path/to/tree-sitter-langs/queries/r
+cp ./queries/* /path/to/tree-sitter-langs/queries/r
+```
 
-Windows (MINGW64)
+### Windows (MINGW64)
 
-1. git clone https://github.com/r-lib/tree-sitter-r.git
-2. gcc ./src/parser.c ./src/scanner.cc -lstdc++ -fPIC -I./ -I./src/ -I./src/tree_sitter --shared -o r.dll
-3. cp ./r.dll /path/to/tree-sitter-langs/langs/bin (/path/to/tree-sitter-langs/ is path of your tree-sitter-langs package)
-4. mkdir /path/to/tree-sitter-langs/queries/r
-5. cp ./queries/* /path/to/tree-sitter-langs/queries/r
+``` bash
+git clone https://github.com/r-lib/tree-sitter-r.git
+gcc ./src/parser.c ./src/scanner.c -lstdc++ -fPIC -I./ -I./src/ -I./src/tree_sitter --shared -o r.dll
+cp ./r.dll /path/to/tree-sitter-langs/langs/bin (/path/to/tree-sitter-langs/ is path of your tree-sitter-langs package)
+mkdir /path/to/tree-sitter-langs/queries/r
+cp ./queries/* /path/to/tree-sitter-langs/queries/r
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![MELPA](https://melpa.org/packages/tree-sitter-ess-r-badge.svg)](https://melpa.org/#/tree-sitter-ess-r)
 [![MELPA Stable](https://stable.melpa.org/packages/tree-sitter-ess-r-badge.svg)](https://stable.melpa.org/#/tree-sitter-ess-r)
-[![Build Status](https://github.com/ShuguangSun/tree-sitter-ess-r/workflows/CI/badge.svg)](https://github.com/ShuguangSun/tree-sitter-ess-r/actions)
+[![Build Status](https://github.com/ShuguangSun/tree-sitter-ess-r/actions/workflows/ci.yml/badge.svg)](https://github.com/ShuguangSun/tree-sitter-ess-r/actions)
 [![License](http://img.shields.io/:license-gpl3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
+
 
 # tree-sitter-ess-r
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ or call interactively `M-x tree-sitter-ess-r-using-r-faces`
 
 ## Make tree-sitter to support R
 
-`/path/to/tree-sitter-langs/` is the path of your
+You can install the [tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs) which includes support
+for R along with a number of other languages. Alternatively if you want to only add support for `tree-sitter-ess-r` to
+your existing Tree-sitter languages you can install manually.
+
+In the following `/path/to/tree-sitter-langs/` is the path of your
 [tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs) package.
 
 ### Linux


### PR DESCRIPTION
The instructions had `./src/scanner.cc` on the second line (i.e. an extra `c` in the file extension) which I have corrected.

At the same time I've...

+ Moved the instructions from a list to code blocks and changed to sub-headings.
+ Moved comment in brackets about `/path/to/tree-sitter-langs` to the start of the section and included a link to the package.
+ Changed instruction for installation to be added to `init.el` rather than `.emacs` as this is the more common location (often `init.el` is nested within a `.emacs` directory).
+ Added instructions for installing and configuring with `use-package`.
+ Fixed the workflow status badge.