### PR TITLE
Adding Emacs 29.1 to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         emacs_version:
           - 27.2
+          - 29.1
 
     steps:
     - name: Setup GNU Emacs

--- a/.github/workflows/eldev_lint.yml
+++ b/.github/workflows/eldev_lint.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         emacs_version:
           - 27.2
+          - 29.1
 
     steps:
     - name: Setup GNU Emacs

--- a/.github/workflows/spell_check_wucuo.yml
+++ b/.github/workflows/spell_check_wucuo.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         emacs_version:
           - 27.2
+          - 29.1
 
     steps:
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
Closes #8

Adds Emacs 29.1 to the `emacs_version` matrix of workflows so that tests are carried out against the newer version of Emacs.